### PR TITLE
Refactor filters out of main

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -1,0 +1,1 @@
+package detector

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,0 +1,42 @@
+package filter
+
+import "gocv.io/x/gocv"
+
+//Filter Defines a computation on a frame,
+//that may do either noise removal or something else.
+type Filter interface {
+
+	//Produce Responsible for allocating a new frame with manipulations on it
+	Produce(gocv.Mat) (gocv.Mat, error)
+
+	//Manipulate Responsible for changing an existing frame
+	Apply(*gocv.Mat) error
+}
+
+//ApplyFilters Applies a chain of manipulations on a frame.
+//The order of manipulations is the same as the slice.
+//Will stop midway if errors encountered.
+func ApplyFilters(frame *gocv.Mat, filters []Filter) error {
+	for _, filter := range filters {
+		err := filter.Apply(frame)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+//CreateFrames Applies a slice of Filters, to produce a slice of frames.
+//The order of frames produces has to be the same as the order of input filters.
+//It will not complete if errors in filters will be encountered.
+func CreateFrames(frame gocv.Mat, filters []Filter) ([]gocv.Mat, error) {
+	resultFrames := make([]gocv.Mat, len(filters))
+	for index, filter := range filters {
+		var err error
+		resultFrames[index], err = filter.Produce(frame)
+		if err != nil {
+			return resultFrames, err
+		}
+	}
+	return resultFrames, nil
+}

--- a/filter/lineapply.go
+++ b/filter/lineapply.go
@@ -10,6 +10,7 @@ func CreateLineApplyFilter() LineApply {
 type LineApply struct {
 }
 
+//Apply Applies white lines to frame
 func (la LineApply) Apply(frame *gocv.Mat) error {
 	for i := 0; i < frame.Cols(); i++ {
 		for j := 0; j < frame.Rows(); j++ {
@@ -23,6 +24,7 @@ func (la LineApply) Apply(frame *gocv.Mat) error {
 	return nil
 }
 
+//Produce Creates new frame with lines applied
 func (la LineApply) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultFrame := frame.Clone()
 	err := la.Apply(&resultFrame)

--- a/filter/lineapply.go
+++ b/filter/lineapply.go
@@ -2,6 +2,7 @@ package filter
 
 import "gocv.io/x/gocv"
 
+//CreateLineApplyFilter Creates LineApply filter with settings
 func CreateLineApplyFilter() LineApply {
 	return LineApply{}
 }

--- a/filter/lineapply.go
+++ b/filter/lineapply.go
@@ -1,0 +1,38 @@
+package filter
+
+import "gocv.io/x/gocv"
+
+func CreateLineApplyFilter() LineApply {
+	return LineApply{}
+}
+
+//LineApply Applies white lines of full height of window when white pixel found
+type LineApply struct {
+}
+
+func (la LineApply) Apply(frame *gocv.Mat) error {
+	for i := 0; i < frame.Cols(); i++ {
+		for j := 0; j < frame.Rows(); j++ {
+			if frame.GetUCharAt(j, i) == 255 {
+				for k := 0; k < frame.Rows(); k++ {
+					frame.SetUCharAt(k, i, 255)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (la LineApply) Produce(frame gocv.Mat) (gocv.Mat, error) {
+	resultFrame := frame.Clone()
+	for i := 0; i < frame.Cols(); i++ {
+		for j := 0; j < frame.Rows(); j++ {
+			if frame.GetUCharAt(j, i) == 255 {
+				for k := 0; k < frame.Rows(); k++ {
+					resultFrame.SetUCharAt(k, i, 255)
+				}
+			}
+		}
+	}
+	return resultFrame, nil
+}

--- a/filter/lineapply.go
+++ b/filter/lineapply.go
@@ -25,14 +25,6 @@ func (la LineApply) Apply(frame *gocv.Mat) error {
 
 func (la LineApply) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultFrame := frame.Clone()
-	for i := 0; i < frame.Cols(); i++ {
-		for j := 0; j < frame.Rows(); j++ {
-			if frame.GetUCharAt(j, i) == 255 {
-				for k := 0; k < frame.Rows(); k++ {
-					resultFrame.SetUCharAt(k, i, 255)
-				}
-			}
-		}
-	}
-	return resultFrame, nil
+	err := la.Apply(&resultFrame)
+	return resultFrame, err
 }

--- a/filter/noise.go
+++ b/filter/noise.go
@@ -14,6 +14,7 @@ type Noise struct {
 	referenceFrame *gocv.Mat
 }
 
+//Apply Applies noise reduction to frame
 func (nf Noise) Apply(frame *gocv.Mat) error {
 	for i := 0; i < frame.Rows(); i++ {
 		for j := 0; j < frame.Cols(); j++ {
@@ -25,7 +26,7 @@ func (nf Noise) Apply(frame *gocv.Mat) error {
 	return nil
 }
 
-//Produce Comparison with previous frame for moving pixels detection and removal
+//Produce Produces new frame with noise reduced
 func (nf Noise) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultingFrame := frame.Clone()
 	err := nf.Apply(&resultingFrame)

--- a/filter/noise.go
+++ b/filter/noise.go
@@ -1,0 +1,39 @@
+package filter
+
+import "gocv.io/x/gocv"
+
+//CreateNoiseFilter Creates noise filter
+func CreateNoiseFilter(referenceFrame *gocv.Mat, frameNumber *int) Noise {
+	return Noise{frameNumber: frameNumber, referenceFrame: referenceFrame}
+}
+
+//NoiseFilter Removes moving noise pixels,
+//Should ease detection
+type Noise struct {
+	frameNumber    *int
+	referenceFrame *gocv.Mat
+}
+
+func (nf Noise) Apply(frame *gocv.Mat) error {
+	for i := 0; i < frame.Rows(); i++ {
+		for j := 0; j < frame.Cols(); j++ {
+			if *nf.frameNumber > 0 && nf.referenceFrame.GetUCharAt(i, j) != frame.GetUCharAt(i, j) {
+				frame.SetUCharAt(i, j, 0)
+			}
+		}
+	}
+	return nil
+}
+
+//Produce Comparison with previous frame for moving pixels detection and removal
+func (nf Noise) Produce(frame gocv.Mat) (gocv.Mat, error) {
+	resultingFrame := frame.Clone()
+	for i := 0; i < frame.Rows(); i++ {
+		for j := 0; j < frame.Cols(); j++ {
+			if *nf.frameNumber > 0 && nf.referenceFrame.GetUCharAt(i, j) != frame.GetUCharAt(i, j) {
+				resultingFrame.SetUCharAt(i, j, 0)
+			}
+		}
+	}
+	return resultingFrame, nil
+}

--- a/filter/noise.go
+++ b/filter/noise.go
@@ -28,12 +28,6 @@ func (nf Noise) Apply(frame *gocv.Mat) error {
 //Produce Comparison with previous frame for moving pixels detection and removal
 func (nf Noise) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultingFrame := frame.Clone()
-	for i := 0; i < frame.Rows(); i++ {
-		for j := 0; j < frame.Cols(); j++ {
-			if *nf.frameNumber > 0 && nf.referenceFrame.GetUCharAt(i, j) != frame.GetUCharAt(i, j) {
-				resultingFrame.SetUCharAt(i, j, 0)
-			}
-		}
-	}
-	return resultingFrame, nil
+	err := nf.Apply(&resultingFrame)
+	return resultingFrame, err
 }

--- a/filter/noise.go
+++ b/filter/noise.go
@@ -7,7 +7,7 @@ func CreateNoiseFilter(referenceFrame *gocv.Mat, frameNumber *int) Noise {
 	return Noise{frameNumber: frameNumber, referenceFrame: referenceFrame}
 }
 
-//NoiseFilter Removes moving noise pixels,
+//Noise Removes moving noise pixels,
 //Should ease detection
 type Noise struct {
 	frameNumber    *int

--- a/filter/subtract.go
+++ b/filter/subtract.go
@@ -6,6 +6,7 @@ import (
 	"gocv.io/x/gocv"
 )
 
+//CreateSubtractFilter Creates subtract filter with settings
 func CreateSubtractFilter(region *image.Rectangle) Subtract {
 	return Subtract{
 		region:     region,

--- a/filter/subtract.go
+++ b/filter/subtract.go
@@ -19,12 +19,14 @@ type Subtract struct {
 	subtractor gocv.BackgroundSubtractorKNN
 }
 
+//Produce Produces a new frame with background subtracted
 func (s Subtract) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultingFrame := frame.Region(*s.region)
 	err := s.Apply(&resultingFrame)
 	return resultingFrame, err
 }
 
+//Apply Applies background subtraction to frame
 func (s Subtract) Apply(frame *gocv.Mat) error {
 	s.subtractor.Apply(*frame, frame)
 	gocv.Threshold(*frame, frame, 125, 255, gocv.ThresholdBinary)

--- a/filter/subtract.go
+++ b/filter/subtract.go
@@ -21,9 +21,8 @@ type Subtract struct {
 
 func (s Subtract) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultingFrame := frame.Region(*s.region)
-	s.subtractor.Apply(frame, &resultingFrame)
-	gocv.Threshold(resultingFrame, &resultingFrame, 125, 255, gocv.ThresholdBinary)
-	return resultingFrame, nil
+	err := s.Apply(&resultingFrame)
+	return resultingFrame, err
 }
 
 func (s Subtract) Apply(frame *gocv.Mat) error {

--- a/filter/subtract.go
+++ b/filter/subtract.go
@@ -1,0 +1,33 @@
+package filter
+
+import (
+	"image"
+
+	"gocv.io/x/gocv"
+)
+
+func CreateSubtractFilter(region *image.Rectangle) Subtract {
+	return Subtract{
+		region:     region,
+		subtractor: gocv.NewBackgroundSubtractorKNN(),
+	}
+}
+
+//Subtract Is a background subtractor, used to find movement
+type Subtract struct {
+	region     *image.Rectangle
+	subtractor gocv.BackgroundSubtractorKNN
+}
+
+func (s Subtract) Produce(frame gocv.Mat) (gocv.Mat, error) {
+	resultingFrame := frame.Region(*s.region)
+	s.subtractor.Apply(frame, &resultingFrame)
+	gocv.Threshold(resultingFrame, &resultingFrame, 125, 255, gocv.ThresholdBinary)
+	return resultingFrame, nil
+}
+
+func (s Subtract) Apply(frame *gocv.Mat) error {
+	s.subtractor.Apply(*frame, frame)
+	gocv.Threshold(*frame, frame, 125, 255, gocv.ThresholdBinary)
+	return nil
+}

--- a/filter/vertical.go
+++ b/filter/vertical.go
@@ -1,0 +1,40 @@
+package filter
+
+import (
+	"image"
+
+	"gocv.io/x/gocv"
+)
+
+//CreateVerticalFilter Creates a Vertical filter
+func CreateVerticalFilter() Vertical {
+	return Vertical{}
+}
+
+//VerticalFilter Finds vertical element of a a frame
+type Vertical struct {
+}
+
+func (vf Vertical) Apply(frame *gocv.Mat) error {
+	gocv.CvtColor(*frame, frame, gocv.ColorGrayToBGR)
+
+	var verticalsize = frame.Rows() / 5
+	verticalStructure := gocv.GetStructuringElement(0, image.Pt(1, verticalsize))
+	gocv.Erode(*frame, frame, verticalStructure)
+	gocv.Dilate(*frame, frame, verticalStructure)
+
+	return nil
+}
+
+//Produce Finds only vertical elements in the frame
+func (vf Vertical) Produce(frame gocv.Mat) (gocv.Mat, error) {
+	resultingFrame := frame.Clone()
+	gocv.CvtColor(frame, &resultingFrame, gocv.ColorGrayToBGR)
+
+	var verticalsize = resultingFrame.Rows() / 5
+	verticalStructure := gocv.GetStructuringElement(0, image.Pt(1, verticalsize))
+	gocv.Erode(resultingFrame, &resultingFrame, verticalStructure)
+	gocv.Dilate(resultingFrame, &resultingFrame, verticalStructure)
+
+	return resultingFrame, nil
+}

--- a/filter/vertical.go
+++ b/filter/vertical.go
@@ -11,7 +11,7 @@ func CreateVerticalFilter() Vertical {
 	return Vertical{}
 }
 
-//VerticalFilter Finds vertical element of a a frame
+//Vertical Finds vertical element of a a frame
 type Vertical struct {
 }
 

--- a/filter/vertical.go
+++ b/filter/vertical.go
@@ -15,6 +15,7 @@ func CreateVerticalFilter() Vertical {
 type Vertical struct {
 }
 
+//Apply Applies vertical element filter to frame
 func (vf Vertical) Apply(frame *gocv.Mat) error {
 	var verticalsize = frame.Rows() / 5
 	verticalStructure := gocv.GetStructuringElement(0, image.Pt(1, verticalsize))
@@ -24,7 +25,7 @@ func (vf Vertical) Apply(frame *gocv.Mat) error {
 	return nil
 }
 
-//Produce Finds only vertical elements in the frame
+//Produce Produces a frame with vertical line filter applied
 func (vf Vertical) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultingFrame := frame.Clone()
 	err := vf.Apply(&resultingFrame)

--- a/filter/vertical.go
+++ b/filter/vertical.go
@@ -16,8 +16,6 @@ type Vertical struct {
 }
 
 func (vf Vertical) Apply(frame *gocv.Mat) error {
-	gocv.CvtColor(*frame, frame, gocv.ColorGrayToBGR)
-
 	var verticalsize = frame.Rows() / 5
 	verticalStructure := gocv.GetStructuringElement(0, image.Pt(1, verticalsize))
 	gocv.Erode(*frame, frame, verticalStructure)

--- a/filter/vertical.go
+++ b/filter/vertical.go
@@ -27,12 +27,6 @@ func (vf Vertical) Apply(frame *gocv.Mat) error {
 //Produce Finds only vertical elements in the frame
 func (vf Vertical) Produce(frame gocv.Mat) (gocv.Mat, error) {
 	resultingFrame := frame.Clone()
-	gocv.CvtColor(frame, &resultingFrame, gocv.ColorGrayToBGR)
-
-	var verticalsize = resultingFrame.Rows() / 5
-	verticalStructure := gocv.GetStructuringElement(0, image.Pt(1, verticalsize))
-	gocv.Erode(resultingFrame, &resultingFrame, verticalStructure)
-	gocv.Dilate(resultingFrame, &resultingFrame, verticalStructure)
-
-	return resultingFrame, nil
+	err := vf.Apply(&resultingFrame)
+	return resultingFrame, err
 }

--- a/frameManipulations.go
+++ b/frameManipulations.go
@@ -6,40 +6,6 @@ import (
 	"gocv.io/x/gocv"
 )
 
-// Comparison with previous frame for moving pixels detection and removal
-func removeMovingNoisePixels(frameCount int, previousFrame *gocv.Mat, frame *gocv.Mat) {
-	for i := 0; i < frame.Rows(); i++ {
-		for j := 0; j < frame.Cols(); j++ {
-			if frameCount > 0 && previousFrame.GetUCharAt(i, j) != frame.GetUCharAt(i, j) {
-				frame.SetUCharAt(i, j, 0)
-			}
-		}
-	}
-}
-
-// Finds only vertical elements in the frame
-func findVerticalElements(cropped *gocv.Mat) {
-	gocv.CvtColor(*cropped, cropped, gocv.ColorGrayToBGR)
-	var verticalsize = cropped.Rows() / 5
-	verticalStructure := gocv.GetStructuringElement(0, image.Pt(1, verticalsize))
-	gocv.Erode(*cropped, cropped, verticalStructure)
-	gocv.Dilate(*cropped, cropped, verticalStructure)
-}
-
-// Apply white lines of full height of window when white pixel found
-func applyWhiteLinesFullHeight(cropped *gocv.Mat) {
-	for i := 0; i < cropped.Cols(); i++ {
-		for j := 0; j < cropped.Rows(); j++ {
-			if cropped.GetUCharAt(j, i) == 255 {
-				for k := 0; k < cropped.Rows(); k++ {
-					cropped.SetUCharAt(k, i, 255)
-				}
-
-			}
-		}
-	}
-}
-
 //find white pixel with biggest X coordinate
 func findBiggestXOfWhitePixel(cropped *gocv.Mat) (biggestX int) {
 
@@ -85,11 +51,4 @@ func machRegionOfInterest(regionResult *gocv.Mat, frame *gocv.Mat, template *goc
 	_, _, _, maxLoc := gocv.MinMaxLoc(*regionResult)
 	regionRect.Min = maxLoc
 	regionRect.Max = image.Point{X: maxLoc.X + templateDims[0], Y: maxLoc.Y + templateDims[1]}
-}
-
-func subtractBackground(frameOriginal *gocv.Mat, regionRect *image.Rectangle, fgbg *gocv.BackgroundSubtractorKNN) gocv.Mat {
-	frameForSubtraction := frameOriginal.Region(*regionRect)
-	fgbg.Apply(frameForSubtraction, &frameForSubtraction)
-	gocv.Threshold(frameForSubtraction, &frameForSubtraction, 125, 255, gocv.ThresholdBinary)
-	return frameForSubtraction
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,25 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"os"
 
+	"github.com/Vilnius-Lithuania-iGEM-2018/lipovision/filter"
 	"gocv.io/x/gocv"
 )
+
+//captureFrame Converts gocv provided handling to idiomatic Go
+func captureFrame(capture *gocv.VideoCapture) (gocv.Mat, error) {
+	frame := gocv.NewMat()
+	ok := capture.Read(&frame)
+	if !ok {
+		return frame, errors.New("failed to read frame from source")
+	}
+	return frame, nil
+}
 
 func main() {
 
@@ -15,46 +28,60 @@ func main() {
 
 	originalWindow := gocv.NewWindow("Original")
 
-	regionSet := false
 	var regionRect image.Rectangle
 	var rectangleColor = color.RGBA{255, 255, 255, 0}
 
-	var fgbg = gocv.NewBackgroundSubtractorKNN()
-
-	cancelled := false
 	previousFrame := gocv.NewMat()
 	frameCount := 0
 
+	frameFilters := []filter.Filter{
+		filter.CreateSubtractFilter(&regionRect),
+		filter.CreateNoiseFilter(&previousFrame, &frameCount),
+	}
+
+	regionFilters := []filter.Filter{
+		filter.CreateVerticalFilter(),
+		filter.CreateLineApplyFilter(),
+	}
+
+	cancelled := false
 	for !cancelled {
-		frame := gocv.NewMat()
-		frameOk := capture.Read(&frame)
-		if !frameOk {
+		// frame is the original, has to represent the original,
+		// so no heavy manipulations should be applied
+		frame, err := captureFrame(capture)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed frame")
 			break
 		}
 
-		frameOriginal := frame.Clone()
 		gocv.CvtColor(frame, &frame, gocv.ColorBGRToGray)
 		gocv.Threshold(frame, &frame, 125, 255, gocv.ThresholdBinaryInv)
 
+		regionSet := false
 		if !regionSet {
 			regionResult := gocv.NewMat()
 			machRegionOfInterest(&regionResult, &frame, &template, &regionRect)
 		} else {
-			cropped := frame.Region(regionRect)
 			croppedWindow := gocv.NewWindow("Cropped")
 
-			frameForSubtraction := subtractBackground(&frameOriginal, &regionRect, &fgbg)
+			manipulatedFrame := frame.Clone()
+			err := filter.ApplyFilters(&manipulatedFrame, frameFilters)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				break
+			}
 
-			removeMovingNoisePixels(frameCount, &previousFrame, &frame)
-			findVerticalElements(&cropped)
-
+			cropped := frame.Region(regionRect)
 			gocv.CvtColor(cropped, &cropped, gocv.ColorBGRToGray)
-
-			applyWhiteLinesFullHeight(&cropped)
+			err = filter.ApplyFilters(&cropped, regionFilters)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				break
+			}
 
 			biggestX := findBiggestXOfWhitePixel(&cropped)
 			// Merge vertical line frame + Subtracted moving bubble frame
-			gocv.AddWeighted(cropped, 1, frameForSubtraction, 1, 0, &cropped)
+			gocv.AddWeighted(cropped, 1, manipulatedFrame, 1, 0, &cropped)
 
 			if isDanger(cropped, biggestX) {
 				gocv.PutText(&cropped, "DANGER!", image.Pt(cropped.Cols()/8, cropped.Rows()/4*3), 0, 0.3, color.RGBA{255, 255, 255, 9}, 1)

--- a/main.go
+++ b/main.go
@@ -76,7 +76,8 @@ func main() {
 
 			cropped := originalFrame.Region(regionRect)
 			croppedForAdd := originalFrame.Region(regionRect)
-			gocv.CvtColor(croppedForAdd, &croppedForAdd, gocv.ColorGrayToBGR)
+			// Origginally conversion was into this type
+			// gocv.CvtColor(*frame, frame, gocv.ColorGrayToBGR)
 			err = filter.ApplyFilters(&cropped, regionFilters)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Only filters are moved. I have an idea to move detectors as a separate type (for example inDanger function). Also I still might do some more decoupling from gocv formats, to make use even more abstract, and testable.